### PR TITLE
Add sample.sha.json manifest with commitSha field

### DIFF
--- a/sample.commitSha.json
+++ b/sample.commitSha.json
@@ -1,0 +1,8 @@
+{
+  "name": "Sample commit SHA KBC Application",
+  "version": "1",
+  "basePath": "https://keboola.github.io/kbc-ui-app-manifest-file/",
+  "scripts": [],
+  "styles": [],
+  "commitSha": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+}


### PR DESCRIPTION
Adds `sample.sha.json` — a test manifest that includes a `commitSha` field.

Used as a test fixture for E2E tests in [keboola/connection#6919](https://github.com/keboola/connection/pull/6919), which adds `commitSha` persistence to the `ui_appsVersions` table and returns it via the Manage API.